### PR TITLE
build: Do not use SemVer-based version bounds for fsspec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ python = "^3.11"
 snakemake-interface-common = "^1.15.0"
 snakemake-interface-storage-plugins = "^3.0.0"
 webdav4 = "^0.9.8"
-fsspec = "^2023.12.2"
+fsspec = ">=2023.12.2"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.12.0"


### PR DESCRIPTION
It does not make sense to use SemVer-based version bounds for `fsspec` since it uses a calendar-based versioning scheme: the “major” version number is just the year of release, and breaking changes are no more likely to occur at year boundaries than mid-year. A bound that pretends the `fsspec` version has SemVer semantics creates unnecessary conflicts.