### PR TITLE
build: Update webdav4 dependency to 0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ documentation = "https://snakemake.github.io/snakemake-plugin-catalog/plugins/st
 python = "^3.11"
 snakemake-interface-common = "^1.15.0"
 snakemake-interface-storage-plugins = "^3.0.0"
-webdav4 = "^0.9.8"
+webdav4 = "^0.10.0"
 fsspec = "^2023.12.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
[This release](https://github.com/skshetry/webdav4/releases/tag/v0.10.0) contains no obvious incompatible changes, and it has compatibility fixes for current `fsspec` releases (although based on the tests that were failing in 0.9.x, this mostly or solely affects the CLI).

If you wanted to use a version range instead, that would be OK too.

See also https://github.com/snakemake/snakemake-storage-plugin-webdav/pull/5, which will conflict trivially with this PR since it modifies an adjacent line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `webdav4` library dependency to version `^0.10.0` for improved performance and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->